### PR TITLE
Add Glossary Page

### DIFF
--- a/source/__init__.py
+++ b/source/__init__.py
@@ -1,7 +1,7 @@
 import os
 from flask import Flask
 
-from .blueprints import index, about, map, data, models, replay, site_map, contact
+from .blueprints import index, about, map, data, models, replay, site_map, contact, glossary
 
 
 def create_app(test_config=None):
@@ -22,5 +22,6 @@ def create_app(test_config=None):
     app.register_blueprint(site_map.bp)
     app.register_blueprint(contact.bp)
     app.register_blueprint(models.bp)
+    app.register_blueprint(glossary.bp)
 
     return app

--- a/source/blueprints/glossary.py
+++ b/source/blueprints/glossary.py
@@ -1,0 +1,13 @@
+from flask import Blueprint, render_template
+
+bp = Blueprint("glossary", __name__, url_prefix="/glossary")
+
+
+@bp.route("/")
+def glossary():
+    """
+    Renders and returns the about page template.
+
+    **Endpoint**: ``/glossary``
+    """
+    return render_template("glossary.html")

--- a/source/static/stylesheets/stylesheet.css
+++ b/source/static/stylesheets/stylesheet.css
@@ -256,5 +256,19 @@ h1 {
     background-color: var(--leaflet-light-gray);
 }
 
+.navy-link {
+    font-weight: bold;
+    text-decoration: underline;
+    color: var(--riddle-navy);
+}
+
+.normal-font {
+    font-weight: normal;
+}
+
+hr {
+    color: var(--riddle-navy);
+}
+
 
 

--- a/source/templates/glossary.html
+++ b/source/templates/glossary.html
@@ -1,0 +1,7 @@
+{% extends 'template.html' %}
+
+{% block title %}Aviation Phraeseology Glossary{% endblock %}
+
+{% block content %}
+
+{% endblock %}

--- a/source/templates/glossary.html
+++ b/source/templates/glossary.html
@@ -8,13 +8,17 @@
         <div class="content navy-font">
             <h1 style="margin-top: 5px; margin-bottom: 10px;">Aviation Phraseology Glossary</h1>
             <p>All definitions come from the Federal Aviation Administration's <a href="https://www.faa.gov/air_traffic/publications/media/pcg_10-12-17.pdf" target="_blank" class="navy-link">Pilot/Controller Glossary</a>. We are presenting only the
-            most commonly used terms and phrases. For a more in-depth look, please look throught the Pilot/Controller Glossary.</p>
+            most commonly used terms and phrases. For a more in-depth look, please look through the Pilot/Controller Glossary.</p>
+            <p>
+                <a href="#a" class="navy-link">A</a>&emsp;<a href="#b" class="navy-link">B</a>&emsp;<a href="#c" class="navy-link">C</a>&emsp;<a href="#d" class="navy-link">D</a>&emsp;<a href="#e" class="navy-link">E</a>&emsp;<a href="#f" class="navy-link">F</a>&emsp;<a href="#g" class="navy-link">G</a>&emsp;<a href="#h" class="navy-link">H</a>&emsp;<a href="#i" class="navy-link">I</a>&emsp;<a href="#j" class="navy-link">J</a>&emsp;<a href="#k" class="navy-link">K</a>&emsp;<a href="#l" class="navy-link">L</a>&emsp;<a href="#m" class="navy-link">M</a>&emsp;<a href="#n" class="navy-link">N</a>&emsp;<a href="#o" class="navy-link">O</a>&emsp;<a href="#p" class="navy-link">P</a>&emsp;<a href="#q" class="navy-link">Q</a>&emsp;<a href="#r" class="navy-link">R</a>&emsp;<a href="#s" class="navy-link">S</a>&emsp;<a href="#t" class="navy-link">T</a>&emsp;<a href="#u" class="navy-link">U</a>&emsp;<a href="#v" class="navy-link">V</a>&emsp;<a href="#w" class="navy-link">W</a>&emsp;<a href="#x" class="navy-link">X</a>&emsp;<a href="#y" class="navy-link">Y</a>&emsp;<a href="#z" class="navy-link">Z</a>
+            </p>
         </div>
         <div class="content navy-font">
+            <hr />
             <h2 id="a">A</h2>
             <p id="abeam"><strong>Abeam</strong><br />An aircraft is "abeam" a fix, point, or object when that fix, point, or object is approximately 90 degrees to the right
             or left of the aircraft track. Abeam indicates a general position rather than a precise point.</p>
-            <p id="abort"><strong>Abort</strong><br />To terminate a preplaned aircraft maneuver; e.g., an aborted takeoff.</p>
+            <p id="abort"><strong>Abort</strong><br />To terminate a preplanned aircraft maneuver; e.g., an aborted takeoff.</p>
             <p id="acknowledge"><strong>Acknowledge</strong><br />Let me know that you have received and understood this message.</p>
             <p id="advise"><strong>Advise Intentions</strong><br />Tell me what you plan to do.</p>
             <p id="affirmative"><strong>Affirmative</strong><br />Yes.</p>
@@ -22,10 +26,10 @@
             which are of operational interest to all aircraft and potentially hazardous to aircraft having limited capability because of lack of equipment, instrumentation, or
             pilot qualifications. AIRMETs concern weather of less severity than that covered by <a href="#sigmet" class="navy-link">SIGMET</a>s or <a href="#csigmets" class="navy-link">Convective SIGMETs</a>.
             AIRMETs cover moderate icing, moderate turbulence, sustained winds of 30 knots or more at the surface, widespread areas
-            of ceilings less than 1,000 feet and/or visibility less than 3 miles, and extensive mountain obsurement.</p>
+            of ceilings less than 1,000 feet and/or visibility less than 3 miles, and extensive mountain obscurement.</p>
             <p id="altread"><strong>Altitude Readout</strong><br />An aircraft's altitude, transmitted via the Mode C transponder feature, that is visually displayed in
             100-foot increments on a radar scope having readout capability.</p>
-            <p id="altrestcan"><strong>Altitude Restrictions are Cancelled</strong><br />Adherence to previously imposed altitude restrictions
+            <p id="altrestcan"><strong>Altitude Restrictions are Canceled</strong><br />Adherence to previously imposed altitude restrictions
             is no longer required during a climb or descent.</p>
             <p id="approachsp"><strong>Approach Speed</strong><br />The recommended speed contained in aircraft manuals used by pilots when making an approach to landing. This speed will vary
             for different segments of an approach as well as for aircraft weight and configuration.</p>
@@ -59,21 +63,21 @@
             <p id="chase"><strong>Chase</strong><br />An aircraft flown in proximity to another aircraft normally to observe its performance during training or testing.</p>
             <p id="circlerunway"><strong>Circle to Runway {Runway Number}</strong><br />Used by ATC to inform the pilot that he/she must circle to land because the runway in use is other than the runway
             aligned with the instrument approach procedure. When the direction of the circling maneuver in relation to the airport/runway is required, the controller will state the direction (eight cardinal
-            compass points) and specify a left or right downwind or base leg as approprate; e.g., "Cleared VOR Runway Three Six Approach circle to Runway Two Two," or "Circle northwest of the airport for a right
+            compass points) and specify a left or right downwind or base leg as appropriate; e.g., "Cleared VOR Runway Three Six Approach circle to Runway Two Two," or "Circle northwest of the airport for a right
             downwind to Runway Two Two."</p>
             <p id="clearance"><strong>Clearance</strong><br />An authorization by air traffic control for the purpose of preventing collision between known aircraft, for an aircraft to proceed under specified
             traffic conditions within controlled airspace. The pilot-in-command of an aircraft may not deviate from the provisions of a visual flight rules (VFR) or instrument flight rules (IFR) air traffic
             clearance except in an emergency or unless an amended clearance has been obtained.<br /><br />Additionally, the pilot may request a different clearance from that which has been issued by air traffic
-            control (ATC) if information available to the pilot makes another course of action more practicable or if aircraft equpment limitations or company procedures forbid compliance with the clearance issued.
+            control (ATC) if information available to the pilot makes another course of action more practicable or if aircraft equipment limitations or company procedures forbid compliance with the clearance issued.
             Pilots may also request clarification or amendment, as appropriate, any time a clearance is not fully understood, or considered unacceptable because of safety of flight. Controllers should, in such instances
             and to the extent of operational practicality and safety, honor the pilot's request.<br /><br /><i>14 CFR Part 91.3(a)</i> states: "The pilot in command of an aircraft is directly responsible for, and is the
             final authority as to, the operation of that aircraft." <strong>The pilot is responsible to request an amended clearance if ATC issues a clearance that would cause a pilot to deviate from a rule or regulation,
                          or in the pilot's opinion, would place the aircraft in jeopardy.</strong></p>
-            <p id="clearancevoid"><strong>Clearance Void If Not Off By {Time}</strong><br />Used by ATC to advise an aircraft that the departure clearance is automatically cancelled if takeoff is not made prior to
+            <p id="clearancevoid"><strong>Clearance Void If Not Off By {Time}</strong><br />Used by ATC to advise an aircraft that the departure clearance is automatically canceled if takeoff is not made prior to
             a specific time. The pilot must obtain a new clearance or cancel his/her IFR flight plan if not off by the specified time.</p>
             <p id="clearedapproach"><strong>Cleared Approach</strong><br />ATC authorization for an aircraft to execute any standard or special instrument approach procedure for that airport. Normally, an aircraft will be
             cleared for a specific instrument approach procedure.</p>
-            <p id="clearedtype"><strong>Cleared {Type Of} Approach</strong><br />ATC authorization for an aircraft to execure a specific instrument approach procedure to an airport; e.g., "Cleared ILS Runway Three Six Approach."</p>
+            <p id="clearedtype"><strong>Cleared {Type Of} Approach</strong><br />ATC authorization for an aircraft to execute a specific instrument approach procedure to an airport; e.g., "Cleared ILS Runway Three Six Approach."</p>
             <p id="clearedfiled"><strong>Cleared as Filed</strong><br />Means the aircraft is cleared to proceed in accordance with the route of flight filed in the flight plan. This clearance does not include the altitude, <a href="#dp" class="navy-link">DP</a>,
             or <a href="#dptransition" class="navy-link">DP Transition</a>.</p>
             <p id="cleartakeoff"><strong>Cleared for Takeoff</strong><br />ATC authorization for an aircraft to depart. It is predicated on known traffic and known physical airport conditions.</p>
@@ -104,13 +108,14 @@
                     <li>An airport clearance limit at locations with a standard/special instrument approach procedure. The CFRs require that if an instrument letdown to an airport is necessary, the pilot shall make the letdown in accordance with a standard/special
                     instrument approach procedure for that airport, or</li>
                     <li>An airport clearance limit at locations are within/below/outside controlled airspace and without a standard/special instrument approach procedure. Such a clearance is <strong>NOT AUTHORIZATION</strong> for the pilot to descend under IFR conditions
-                    below the applicable minimum IFR altitude nor does it imply that ATC is ecercising control over aircraft in Class G airspace; however, it provides a means for the aircraft to proceed to destination airport, descend, and land in accordance with applicable CFRs governing VFR
+                    below the applicable minimum IFR altitude nor does it imply that ATC is exercising control over aircraft in Class G airspace; however, it provides a means for the aircraft to proceed to destination airport, descend, and land in accordance with applicable CFRs governing VFR
                     flight operations. Also, this provides search and rescue protection until such time as the IFR flight plan is closed.</li>
                 </ol></p>
             <hr />
         </div>
         <div class="content navy-font">
             <h2 id="d">D</h2>
+            <p id="dptransition"><strong>Departure Procedure (DP) Transition </strong><br />A published procedure used to connect the basic <a href="#dp" class="navy-link">DP</a> to one of several en route airways/jet routes, or a published procedure (STAR Transition) used to connect one of several en route airways/jet routes to the basic STAR.</p>
             <p id="direct"><strong>Direct</strong><br />Straight line flight between to navigational aids, fixes, points, or any combination thereof. When used by pilots in describing off-airway routes, points defining direct route segments become compulsory reporting points unless the aircraft is under
             radar contact.</p>
             <hr />
@@ -139,7 +144,7 @@
         <div class="content navy-font">
             <h2 id="g">G</h2>
             <p id="goahead"><strong>Go Ahead</strong><br />Proceed with your message. <i>Not to be used for any other purpose.</i></p>
-            <p id="goaround"><strong>Go Around</strong><br />Insstructions for a pilot to abandon his/her approach to landing. Additional instructions may follow. Unless otherwise advised by ATC, a VFR aircraft or an aircraft conducting visual approach should overfly the runway while climbing to traffic pattern
+            <p id="goaround"><strong>Go Around</strong><br />Instructions for a pilot to abandon his/her approach to landing. Additional instructions may follow. Unless otherwise advised by ATC, a VFR aircraft or an aircraft conducting visual approach should overfly the runway while climbing to traffic pattern
             altitude and enter the traffic pattern via the crosswind leg. A pilot on an IFR flight plan making an instrument approach should execute the published <a href="#missedapproach" class="navy-link">missed approach</a> procedure or proceed as instructed by ATC; e.g., "Go around" (additional instructions if required).</p>
             <hr />
         </div>
@@ -154,7 +159,7 @@
         <div class="content navy-font">
             <h2 id="i">I</h2>
             <p id="isayagain"><strong>I Say Again</strong><br />The message will be repeated.</p>
-            <p id="ident"><strong>Ident</strong><br />A request for a pilor to activate the aircraft transponder identification feature. This will help the controller to confirm an aircraft identity or to identify an aircraft.</p>
+            <p id="ident"><strong>Ident</strong><br />A request for a pilot to activate the aircraft transponder identification feature. This will help the controller to confirm an aircraft identity or to identify an aircraft.</p>
             <p id="ifnotransmission"><strong>If No Transmission Received For {Time}</strong><br />Used by ATC in radar approaches to prefix procedures which should be followed by the pilot in event of lost communications.</p>
             <p id="immediately"><strong>Immediately</strong><br />Used by ATC or pilots when such action compliance is required to avoid an imminent situation.</p>
             <p id="increasespeed"><strong>Increase Speed to {Speed}</strong><br />An ATC procedure used to request pilots to adjust aircraft speed to a specific value for the purpose of providing a desired spacing. Pilots are expected to maintain a speed of plus or minus 10 knots or 0.02 Mach number of the specified speed.
@@ -164,6 +169,8 @@
                     <li>"Increase speed to (speed in knots)" or "Increase speed (number of knots) knots."</li>
                 </ol>
             </p>
+            <p id="dp"><strong>Instrument Departure Procedure (DP)</strong><br />A preplanned instrument flight rule (IFR) departure procedure published for pilot use, in graphic or textual format, that provides obstruction clearance from the terminal area to the appropriate en route structure. There are two types of DP, Obstacle Departure Procedure (ODP), printed either textually or
+            graphically, and, Standard Instrument Departure (SID), which is always printed graphically.</p>
             <hr />
         </div>
         <div class="content navy-font">
@@ -174,9 +181,9 @@
         <div class="content navy-font">
             <h2 id="k">K</h2>
             <p>No commonly used terms/phrases. Please check the <a href="https://www.faa.gov/air_traffic/publications/media/pcg_10-12-17.pdf" target="_blank" class="navy-link">FAA Glossary</a> for more in-depth terms and definitions.</p>
+            <hr />
         </div>
         <div class="content navy-font">
-            <hr />
             <h2 id="l">L</h2>
             <p id="lowaltitudealert">
                 <strong>Low Altitude Alert, Check Your Altitude Immediately</strong><br />A safety alert issued by ATC to aircraft under their control if ATC is aware the aircraft is at an altitude which, in the controller's judgement, places the aircraft in unsafe proximity to terrain, obstructions, or other aircraft.
@@ -189,36 +196,213 @@
                     </li>
                 </ol>
             </p>
+            <hr />
         </div>
         <div class="content navy-font">
-            <hr />
             <h2 id="m">M</h2>
-            <p id="maintain"><strong>Maintain</strong><br />
-            <ol type="a">
-                <li>Concerning altitude/flight level, the term means to remain at the altitude/flight level specified. The phrase "climb and" or "descend and" normally precedes "maintain" and the altitude assignment; e.g., "descend and maintain 5,000."</li>
-                <li>Concerning other ATC instructions, the term is used in its literal sense; e.g., maintain VFR.</li>
-                </ol></p>
+            <p id="maintain">
+                <strong>Maintain</strong><br />
+                <ol type="a">
+                    <li>Concerning altitude/flight level, the term means to remain at the altitude/flight level specified. The phrase "climb and" or "descend and" normally precedes "maintain" and the altitude assignment; e.g., "descend and maintain 5,000."</li>
+                    <li>Concerning other ATC instructions, the term is used in its literal sense; e.g., maintain VFR.</li>
+                </ol>
+            </p>
             <p id="makeshortapproach"><strong>Make Short Approach</strong><br />Used by ATC to inform a pilot to alter his/her traffic patter so as to make a short final approach.</p>
             <p id="mayday"><strong>Mayday</strong><br />The international radiotelephony distress signal. When repeated three times, it indicates imminent and grave danger and that immediate assistance is requested</p>
-            <p id="mea"><strong>Minimum En Route IFR Altitude (MEA)</strong><br />The lowest published altitude between radio fixes which assures acceptable navigational signal coverage and meets obstacle clearance requirements between those fixes. The MEA prescribed for a Federal airway or segment thereof, area navigation low or high route, or other direct route applies to the entire width of the airway, segment, or route between the radio fixes
-            defining the airway, segment, or route.</p>
-            <p id="mia"><strong>Minimum IFR Altitudes (MIA)</strong><br />Minimum altitudes for IFR operations prescribed in <i>14 CFR Part 91</i>. These altitudes are published on aeronautical charts and prescribed in <i>14 CFR Part 95</i> for airways and routes, and in <i>14 CFR Part 97</i> for standard instrument approach procedures. If no applicable minimum altitude is prescribed in <i>14 CFR Part 95</i> or <i>14 CFR Part 97</i>, the following minimum IFR altitude applies:
+            <p id="mea">
+                <strong>Minimum En Route IFR Altitude (MEA)</strong><br />The lowest published altitude between radio fixes which assures acceptable navigational signal coverage and meets obstacle clearance requirements between those fixes. The MEA prescribed for a Federal airway or segment thereof, area navigation low or high route, or other direct route applies to the entire width of the airway, segment, or route between the radio fixes
+                defining the airway, segment, or route.
+            </p>
+            <p id="mia">
+                <strong>Minimum IFR Altitudes (MIA)</strong><br />Minimum altitudes for IFR operations prescribed in <i>14 CFR Part 91</i>. These altitudes are published on aeronautical charts and prescribed in <i>14 CFR Part 95</i> for airways and routes, and in <i>14 CFR Part 97</i> for standard instrument approach procedures. If no applicable minimum altitude is prescribed in <i>14 CFR Part 95</i> or <i>14 CFR Part 97</i>, the following minimum IFR altitude applies:
                 <ol type="a">
                     <li>In designated mountainous areas, 2,000 feet above the highest obstacle within a horizontal distance of 4 nautical miles from the course to be flown; or</li>
                     <li>Other than mountainous areas, 1,000 feet above the highest obstacle within a horizontal distance of 4 nautical miles from the course to be flown; or</li>
                     <li>As otherwise authorized by the Administrator or assigned by ATC.</li>
-                </ol></p>
-            <p id="moca"><strong>Minimum Obstruction Clearance Altitude (MOCA)</strong><br />The lowest published altitude in effect between radio fixes on VOR airways, off-airway routes, or route segmentse which meets obstacle clearance requirements for the entire route segment and which assures acceptable navigational signal coverage only within 25 statute (22 nautical) miles of a VOR.</p>
-            <p id="mva"><strong>Minimum Vectoring Altitude (MVA)</strong><br />The lowest MSL altitude at which an IFR aircraft will be vectored by a radar controller, except as otherwise authorized for radar approaches, departures, and <a href="#missedapproach" class="navy-link">missed approaches</a>. The altitude meets IFR obstacle clearance criteria. It may be lower than the published <a href="#mea" class="navy-link">MEA</a>
-            along an airway or J-route segment. It may be utilized for radar vectoring only upon the controller's determination that an adequate radar return is being received from the aircraft being controlled. Charts depicting minimum vectoring altitudes are normally available only to the controllers and not to pilots.</p>
-            <p id="missedapproach"><strong>Missed Approach</strong><br />
-            <ol type="a">
-                <li>A maneuver conducted by a pilot when an instrument approach cannot be completed to a landing. The route of flight and altitude are shown on instrument approach procedure charts. A pilot executing a missed approach prior to the <a href="#map" class="navy-link">Missed Approach Point (MAP)</a> must continue along the final approach to the <a href="#map" class="navy-link">MAP</a>.</li>
-                <li>A term used by the pilot to inform ATC that he/she is executing the missed approach.</li>
-                <li>At locations where ATC radar services is provided, the pilot should conform to radar vectors when provided by ATC in lieu of the published missed approach procedure.</li>
-                </ol></p>
+                </ol>
+            </p>
+            <p id="moca"><strong>Minimum Obstruction Clearance Altitude (MOCA)</strong><br />The lowest published altitude in effect between radio fixes on VOR airways, off-airway routes, or route segments which meets obstacle clearance requirements for the entire route segment and which assures acceptable navigational signal coverage only within 25 statute (22 nautical) miles of a VOR.</p>
+            <p id="mva">
+                <strong>Minimum Vectoring Altitude (MVA)</strong><br />The lowest MSL altitude at which an IFR aircraft will be vectored by a radar controller, except as otherwise authorized for radar approaches, departures, and <a href="#missedapproach" class="navy-link">missed approaches</a>. The altitude meets IFR obstacle clearance criteria. It may be lower than the published <a href="#mea" class="navy-link">MEA</a>
+                along an airway or J-route segment. It may be utilized for radar vectoring only upon the controller's determination that an adequate radar return is being received from the aircraft being controlled. Charts depicting minimum vectoring altitudes are normally available only to the controllers and not to pilots.
+            </p>
+            <p id="missedapproach">
+                <strong>Missed Approach</strong><br />
+                <ol type="a">
+                    <li>A maneuver conducted by a pilot when an instrument approach cannot be completed to a landing. The route of flight and altitude are shown on instrument approach procedure charts. A pilot executing a missed approach prior to the <a href="#map" class="navy-link">Missed Approach Point (MAP)</a> must continue along the final approach to the <a href="#map" class="navy-link">MAP</a>.</li>
+                    <li>A term used by the pilot to inform ATC that he/she is executing the missed approach.</li>
+                    <li>At locations where ATC radar services is provided, the pilot should conform to radar vectors when provided by ATC in lieu of the published missed approach procedure.</li>
+                </ol>
+            </p>
             <p id="map"><strong>Missed Approach Point (MAP)</strong><br />A point prescribed in each instrument approach procedure at which a <a href="#missedapproach" class="navy-link">missed approach</a> procedure shall be executed if the required visual reference does not exist.</p>
-
+            <hr />
+        </div>
+        <div class="navy-font content">
+            <h2 id="n">N</h2>
+            <p id="navaid"><strong>Navigational Aid (NAVAID)</strong><br />Any visual or electronic device airborne or on the surface which provides point-to-point guidance information or position data to aircraft in flight.</p>
+            <p id="negative"><strong>Negative</strong><br />"No," or "permission not granted," or "that is not correct."</p>
+            <p id="negativecontact"><strong>Negative Contact</strong><br />Used by pilots to inform ATC that:
+                <ol type="a">
+                    <li>Previously issued traffic is not in sight. It may be followed by the pilot's request for the controller to provide assistance in avoiding the traffic.</li>
+                    <li>They were unable to contact ATC on a particular frequency.</li>
+                </ol></p>
+            <p id="nygyroapproach"><strong>No Gyro Approach</strong>A radar approach/vector provided in case of a malfunctioning gyro-compass or directional gyro. Instead of providing the pilot with headings to be flown, the controller observes the radar track and issues control instructions "turn right/left" or "stop turn" as appropriate.</p>
+            <p id="nogyrovector"><strong>No Gyro Vector</strong><br />A radar approach/vector provided in case of a malfunctioning gyro-compass or directional gyro. Instead of providing the pilot with headings to be flown, the controller observes the radar track and issues control instructions "turn right/left" or "stop turn" as appropriate.</p>
+            <p id="ntz"><strong>No Transgression Zone (NTZ)</strong><br />The NTZ is a 2,000 foot wide zone, located equidistant between parallel runway or SOIA final approach courses in which flight is normally not allowed.</p>
+            <p id="nordo"><strong>NORDO (No Radio)</strong><br />Aircraft that cannot or do not communicate by radio when radio communication is required is referred to as "NORDO."</p>
+            <p id="numeroustargets"><strong>Numerous Targets Vicinity {Location}</strong><br />A traffic advisory issued by ATC to advise pilots that targets on the radar scope are too numerous to issue individually.</p>
+            <hr />
+        </div>
+        <div class="content navy-font">
+            <h2 id="o">O</h2>
+            <p id="oncourse"><strong>On Course</strong><br />
+                <ol type="a">
+                    <li>Used to indicate that an aircraft is established on the route centerline.</li>
+                    <li>Used by ATC to advise a pilot making a radar approach that his/her aircraft is lined up on the final approach course.</li>
+                </ol></p>
+            <p id="out"><strong>Out</strong><br />The conversation is ended and no response is expected.</p>
+            <p id="over"><strong>Over</strong><br />My transmission is ended; I expect a response.</p>
+            <hr />
+        </div>
+        <div class="content navy-font">
+            <h2 id="p">P</h2>
+            <p id="pilotsdiscretion"><strong>Pilot's Discretion</strong><br />When used in conjunction with altitude assignments, means that ATC has offered the pilot the option of starting climb or descent whenever he/she wishes and conducting the climb or descent at any rate he/she wishes. He/she
+            may temporarily level off at any intermediate altitude. However, once he/she has vacated an altitude, he/she may not return to that altitude.</p>
+            <hr />
+        </div>
+        <div class="content navy-font">
+            <h2 id="q">Q</h2>
+            <p>No commonly used terms/phrases. Please check the <a href="https://www.faa.gov/air_traffic/publications/media/pcg_10-12-17.pdf" target="_blank" class="navy-link">FAA Glossary</a> for more in-depth terms and definitions.</p>
+            <hr />
+        </div>
+        <div class="content navy-font">
+            <h2 id="r">R</h2>
+            <p id="radarcontact"><strong>Radar Contact</strong><br />
+                <ol type="a">
+                    <li>Used by ATC to inform an aircraft that it is identified using an approved ATC surveillance source on an air traffic controller's display and that radar flight following will be provided until radar service is terminated. Radar service may also be provided within the limits of necessity and capability. When
+                    a pilot is informed of "radar contact," he/she automatically discontinues reporting over compulsory reporting points.</li>
+                    <li>The term used to inform the controller that the aircraft is identified and approval is granted for the aircraft to enter the receiving controllers airspace.</li>
+                </ol>
+            </p>
+            <p id="radarcontactlost"><strong>Radar Contact Lost</strong><br />Used by ATC to inform a pilot that the surveillance data used to determine the aircraft's position is no longer being received, or is no longer reliable and radar service is no longer being provided. The loss may be attributed to several factors including the aircraft
+            merging with weather or ground clutter, the aircraft operating below radar line of sight coverage, the aircraft entering an area of poor radar return, failure of the aircraft's equipment, or failure of the surveillance equipment.</p>
+            <p id="radarserviceterminated"><strong>Radar Service Terminated</strong><br />Used by ATC to inform a pilot that he/she will no longer be provided any of the services that could be received while in radar contact. Radar service is automatically terminated, and the pilot is not advised in the following cases:
+                <ol type="a">
+                    <li>An aircraft cancels its IFR flight plan, except within Class B airspace, Class C airspace, a TRSA, or where Basic Radar service is provided.</li>
+                    <li>An aircraft conducting an instrument, visual, or contact approach has landed or has been instructed to change to advisory frequency.</li>
+                    <li>An arriving VFR aircraft, receiving radar service to a tower-controlled airport within Class B airspace, Class C airspace, a TRSA, or where sequencing service is provided, has landed; or to all other airports, is instructed to change to tower or advisory frequency.</li>
+                    <li>An aircraft completes a radar approach.</li>
+                </ol>
+            </p>
+            <p id="readback"><strong>Read Back</strong><br />Repeat my message back to me.</p>
+            <p id="reducespeed"><strong>Reduce Speed to {Speed}</strong><br />An ATC procedure used to request pilots to adjust aircraft speed to a specific value for the purpose of providing desired spacing. Pilots are expected to maintain a speed of plus or minus 10 knots or 0.02 Mach number of the specified speed. Examples of speed adjustments are:
+                <ol type="a">
+                    <li>"Reduce speed to Mach point (number.)"</li>
+                    <li>"Reduce speed to (speed in knots)" or "Reduce speed (number of knots) knots."</li>
+                </ol>
+            </p>
+            <p id="report"><strong>Report</strong><br />Used to instruct pilots to advise ATC of specified information; e.g., "Report passing Hamilton VOR."</p>
+            <p id="requestfullrouteclearance"><strong>Request Full Route Clearance</strong><br />Used by pilots to request that the entire route of flight be read verbatim in an ATC clearance. Such request should be made to preclude receiving an ATC clearance based on the original filed flight plan when a filed IFR flight plan has been revised by the pilot,
+            company, or operations prior to departure.</p>
+            <p id="resumenormalspeed"><strong>Resume Normal Speed</strong><br />Used by ATC to advise a pilot to resume an aircraft's normal operating speed. It is issued to terminate a speed adjustment where no published speed restrictions apply. It does not delete speed restrictions in published procedures of upcoming segments of flight. This does not relieve the pilot of those
+            speed restrictions, which are applicable to <i>14 CFR Section 91.117</i>.</p>
+            <p id="resumeownnavigation"><strong>Resume Own Navigation</strong><br />Used by ATC to advise a pilot to resume his/her own navigational responsibility. It is issued after completion of a radar vector or when radar contact is lost while the aircraft is being radar vectored.</p>
+            <p id="roger"><strong>Roger</strong><br />I have received all of your last transmission. It should not be used to answer a question requiring a yes or a no answer.</p>
+            <p id="runwayheading"><strong>Runway Heading</strong><br />The magnetic direction that corresponds with the runway centerline extended, not the painted runway number. When cleared to "fly or maintain runway heading," pilots are expected to fly or maintain the heading that corresponds with the extended centerline of the departure runway. Drift correction
+            shall not be applied; e.g., Runway 4, actual magnetic heading of the runway centerline 044, fly 044.</p>
+            <hr />
+        </div>
+        <div class="content navy-font">
+            <h2 id="s">S</h2>
+            <p id="sayagain"><strong>Say Again</strong><br />Used to request a repeat of the last transmission. Usually specifies transmission or portion thereof not understood or received; e.g., "Say again all after ABRAM VOR."</p>
+            <p id="sayaltitude"><strong>Say Altitude</strong><br />Used by ATC to ascertain an aircraft's specific altitude/flight level. When the aircraft is climbing or descending, the pilot should state the indicated altitude rounded to the nearest 100 feet.</p>
+            <p id="sayheading"><strong>Say Heading</strong><br />Used by ATC to request an aircraft heading. The pilot should state the actual heading of the aircraft.</p>
+            <p id="sigmet"><strong>Significant Meteorological Information (SIGMET)</strong><br />A weather advisory issued concerning weather significant to the safety of all aircraft. SIGMET advisories cover severe and extreme turbulence, severe icing, and widespread dust or sandstorms that reduce visibility to less than 3 miles.</p>
+            <p id="speakslower"><strong>Speak Slower</strong><br />Used in verbal communications as a request to reduce speech rate.</p>
+            <p id="squawk"><strong>Squawk {Mode, Code, Function}</strong><br />Activate specific modes/codes/functions on the aircraft transponder; e.g., "Squawk three/alpha, two one zero five, low."</p>
+            <p id="standby"><strong>Stand By</strong><br />Means the controller or pilot must pause for a few seconds, usually to attend to other duties of a higher priority. Also means to wait as in "stand by for clearance." The caller should reestablish contact if a delay is lengthy. "Stand by" is not an approval or denial.</p>
+            <p id="stopaltitudesquawk"><strong>Stop Altitude Squawk</strong><br />Used by ATC to inform an aircraft to turn-off the automatic altitude reporting feature of its transponder. It is issued when the verbally reported altitude varies 300 feet or more from the automatic altitude report.</p>
+            <p id="stopburst"><strong>Stop Burst</strong><br />Used by ATC to request a pilot to suspend electronic attack activity.</p>
+            <p id="stopbuzzer"><strong>Stop Buzzer</strong><br />Used by ATC to request a pilot to suspend electronic attack activity.</p>
+            <p id="stopsquawk"><strong>Stop Squawk {Mode or Code}</strong><br />Used by ATC to tell the pilot to turn specific functions of the aircraft transponder off.</p>
+            <p id="stopstream"><strong>Stop Stream</strong><br />Used by ATC to request a pilot to suspend electronic attack activity.</p>
+            <hr />
+        </div>
+        <div class="content navy-font">
+            <h2 id="t">T</h2>
+            <p id="thatiscorrect"><strong>That is Correct</strong><br />The understanding you have is right.</p>
+            <p id="trafficalert"><strong>Traffic Alert {Aircraft Call Sign}, Turn {Left/Right} Immediately, {Climb/Descend} and Maintain {Altitude}</strong><br />A safety alert issued by ATC to aircraft under their control if ATC is aware the aircraft is at an altitude which, in the controller's judgement, places the aircraft in unsafe proximity to terrain, obstructions, or other aircraft. The
+            controller may discontinue the issuance of further alerts if the pilot advises he/she is taking action to correct the situation or had the other aircraft in sight.
+                <ol type="a">
+                    <li><strong>Terrain/Obstruction Alert</strong><br />A safety alert issued by ATC to aircraft under their control if ATC is aware the aircraft is at an altitude which, in the controller's judgement, places the aircraft in unsafe proximity to terrain/obstructions.'</li>
+                    <li>
+                    <strong>Aircraft Conflict Alert</strong><br />A safety alert issued by ATC to aircraft under their control if ATC is aware of an aircraft that is not under their control at an altitude which, in the controller's judgement, places both aircraft in unsafe proximity to each other. With the alert, ATC will offer the pilot an alternate course of action
+                    when feasible.
+                    </li>
+                </ol>
+            </p>
+            <p id="trafficinsight"><strong>Traffic in Sight</strong><br />Used by pilots to inform a controller that previously issued traffic is in sight.</p>
+            <p id="trafficnofactor"><strong>Traffic No Factor</strong><br />Indicates that the traffic described in a previously issued traffic advisory is no factor.</p>
+            <p id="trafficnolongerobserved"><strong>Traffic No Longer Observed</strong><br />Indicates that the traffic described in a previously issued traffic advisory is no longer depicted on radar, but may still be a factor.</p>
+            <p id="transmittingintheblind"><strong>Transmitting in the Blind</strong><br />A transmission from one station to other stations in circumstances where two-way communication cannot be established, but where it is believed that the called stations may be able to receive the transmission.</p>
+            <hr />
+        </div>
+        <div class="content navy-font">
+            <h2 id="u">U</h2>
+            <p id="unable"><strong>Unable</strong><br />Indicates inability to comply with a specific instruction, request, or clearance.</p>
+            <hr />
+        </div>
+        <div class="content navy-font">
+            <h2 id="v">V</h2>
+            <p id="verify"><strong>Verify</strong><br />Request confirmations of information; e.g., "verify assigned altitude."</p>
+            <p id="verifyspecific"><strong>Verify Specific Direction of Takeoff (or Turns After Takeoff)</strong><br />Used by ATC to ascertain an aircraft's direction of takeoff and/or direction of turn after takeoff. It is normally used for IFR departures from an airport not having a control tower. When direct communication with the pilot is not possible, the request and information may
+            be relayed through an FSS, dispatcher, or by other means.</p>
+            <p id="vfrconditions"><strong>VFR Conditions</strong>Weather conditions equal to or better than the minimum for flight under visual flight rules. The term may be used as an ATC clearance/instruction only when:
+                <ol type="a">
+                    <li>An IFR aircraft requests a climb/descent in VFR conditions.</li>
+                    <li>The clearance will result in noise abatement benefits where part of the IFR departure route does not conform to an FAA approved noise abatement route or altitude.</li>
+                    <li>A pilot has requested a practice instrument approach and is not on an IFR flight plan.</li>
+                </ol><br />
+            <i>Note: All pilots receiving this authorization must comply with the VFR visibility and distance from cloud criteria in</i> 14 CFR Part 91<i>. Use of the term does not relieve controllers of their responsibility to separate aircraft in Class B and Class C airspace or TRSAs as required by</i> FAA Order JO 7110.65<i>. When used as an ATC clearance/instruction, the term may be abbreviated
+                "VFR;" e.g., "MAINTAIN VFR," "CLIMB/DESCEND VFR," etc.</i>
+            </p>
+            <p id="vfrnotrecommended"><strong>VFR Not Recommended</strong><br />An advisory provided by a flight service station to a pilot during a preflight or inflight weather briefing that flight under visual flight rules is not recommended. To be given when the current and/or forecast weather conditions are at or below VFR minimums. It does not
+            abrogate the pilot's authority to make his/her own decision.</p>
+            <p id="vfrontop"><strong>VFR-On-Top</strong><br />ATC authorization for an IFR aircraft to operate in VFR conditions at any appropriate VFR altitude (as specified in <i>14 CFR</i> and as restricted by ATC). A pilot receiving this authorization must comply with the VFR visibility, distance from cloud criteria, and the minimum IFR altitudes specified in <i>14 CFR Part 91</i>.
+            The use of this term does not relieve controllers of their responsibility to separate aircraft in Class B and Class C airspace or TRSAs as required by <i>FAAO JO 7110.65</i>.</p>
+            <hr />
+        </div>
+        <div class="content navy-font">
+            <h2 id="w">W</h2>
+            <p id="whenable"><strong>When Able</strong><br />
+                <ol type="a">
+                    <li>In conjunction with ATC instructions, give the pilot the latitude to delay compliance until a condition or event has been reconciled. Unlike "pilot discretion," when instructions are prefaced "when able," the pilot is expected to seek the first opportunity to comply.</li>
+                    <li>In conjuction with a weather deviation clearance, requires the pilot to determine when he/she is clear of weather, then execute ATC instructions.</li>
+                    <li>Once a maneuver has been initiated, the pilot is expected to continue until the specifications of the instructions have been met. "When able," should not be used when expeditious compliance is required.</li>
+                </ol>
+            </p>
+            <p id="wilco"><strong>WILCO</strong><br />I have received your message, understand it, and will comply with it.</p>
+            <p id="wordstwice"><strong>Words Twice</strong><br />
+                <ol type="a">
+                    <li>As a request: "Communication is difficult. Please say every phrase twice."</li>
+                    <li>As information: "Since communications are difficult, every phrase in this message will be spoken twice."</li>
+                </ol>
+            </p>
+            <hr />
+        </div>
+        <div class="content navy-font">
+            <h2 id="x">X</h2>
+            <p>No commonly used terms/phrases. Please check the <a href="https://www.faa.gov/air_traffic/publications/media/pcg_10-12-17.pdf" target="_blank" class="navy-link">FAA Glossary</a> for more in-depth terms and definitions.</p>
+            <hr />
+        </div>
+        <div class="content navy-font">
+            <h2 id="y">Y</h2>
+            <p>No commonly used terms/phrases. Please check the <a href="https://www.faa.gov/air_traffic/publications/media/pcg_10-12-17.pdf" target="_blank" class="navy-link">FAA Glossary</a> for more in-depth terms and definitions.</p>
+            <hr />
+        </div>
+        <div class="content navy-font">
+            <h2 id="z">Z</h2>
+            <p>No commonly used terms/phrases. Please check the <a href="https://www.faa.gov/air_traffic/publications/media/pcg_10-12-17.pdf" target="_blank" class="navy-link">FAA Glossary</a> for more in-depth terms and definitions.</p>
         </div>
     </div>
 </div>

--- a/source/templates/glossary.html
+++ b/source/templates/glossary.html
@@ -31,17 +31,17 @@
             for different segments of an approach as well as for aircraft weight and configuration.</p>
             <p id="aocma"><strong>Appropriate Obstacle Clearance Minimum Altitude</strong><br />Any of the following:<br />
             <ul>
-                <li><a href="#meria" class="navy-link">Minimum En Route IFR Altitude</a></li>
-                <li><a href="#mia" class="navy-link">Minimum IFR Altitude</a></li>
-                <li><a href="#moca" class="navy-link">Minimum Obstruction Clearance Altitude</a></li>
-                <li><a href="#mva" class="navy-link">Minimum Vectoring Altitude</a></li>
+                <li><a href="#mea" class="navy-link">Minimum En Route IFR Altitude (MEA)</a></li>
+                <li><a href="#mia" class="navy-link">Minimum IFR Altitude (MIA)</a></li>
+                <li><a href="#moca" class="navy-link">Minimum Obstruction Clearance Altitude (MOCA)</a></li>
+                <li><a href="#mva" class="navy-link">Minimum Vectoring Altitude (MVA)</a></li>
              </ul></p>
             <p id="aocma"><strong>Appropriate Terrain Clearance Minimum Altitude</strong><br />Any of the following:<br />
             <ul>
-                <li><a href="#meria" class="navy-link">Minimum En Route IFR Altitude</a></li>
-                <li><a href="#mia" class="navy-link">Minimum IFR Altitude</a></li>
-                <li><a href="#moca" class="navy-link">Minimum Obstruction Clearance Altitude</a></li>
-                <li><a href="#mva" class="navy-link">Minimum Vectoring Altitude</a></li>
+                <li><a href="#mea" class="navy-link">Minimum En Route IFR Altitude (MEA)</a></li>
+                <li><a href="#mia" class="navy-link">Minimum IFR Altitude (MIA)</a></li>
+                <li><a href="#moca" class="navy-link">Minimum Obstruction Clearance Altitude (MOCA)</a></li>
+                <li><a href="#mva" class="navy-link">Minimum Vectoring Altitude (MVA)</a></li>
              </ul></p>
             <hr />
         </div>
@@ -199,6 +199,18 @@
                 <li>Concerning other ATC instructions, the term is used in its literal sense; e.g., maintain VFR.</li>
                 </ol></p>
             <p id="makeshortapproach"><strong>Make Short Approach</strong><br />Used by ATC to inform a pilot to alter his/her traffic patter so as to make a short final approach.</p>
+            <p id="mayday"><strong>Mayday</strong><br />The international radiotelephony distress signal. When repeated three times, it indicates imminent and grave danger and that immediate assistance is requested</p>
+            <p id="mea"><strong>Minimum En Route IFR Altitude (MEA)</strong><br />The lowest published altitude between radio fixes which assures acceptable navigational signal coverage and meets obstacle clearance requirements between those fixes. The MEA prescribed for a Federal airway or segment thereof, area navigation low or high route, or other direct route applies to the entire width of the airway, segment, or route between the radio fixes
+            defining the airway, segment, or route.</p>
+            <p id="mia"><strong>Minimum IFR Altitudes (MIA)</strong><br />Minimum altitudes for IFR operations prescribed in <i>14 CFR Part 91</i>. These altitudes are published on aeronautical charts and prescribed in <i>14 CFR Part 95</i> for airways and routes, and in <i>14 CFR Part 97</i> for standard instrument approach procedures. If no applicable minimum altitude is prescribed in <i>14 CFR Part 95</i> or <i>14 CFR Part 97</i>, the following minimum IFR altitude applies:
+                <ol type="a">
+                    <li>In designated mountainous areas, 2,000 feet above the highest obstacle within a horizontal distance of 4 nautical miles from the course to be flown; or</li>
+                    <li>Other than mountainous areas, 1,000 feet above the highest obstacle within a horizontal distance of 4 nautical miles from the course to be flown; or</li>
+                    <li>As otherwise authorized by the Administrator or assigned by ATC.</li>
+                </ol></p>
+            <p id="moca"><strong>Minimum Obstruction Clearance Altitude (MOCA)</strong><br />The lowest published altitude in effect between radio fixes on VOR airways, off-airway routes, or route segmentse which meets obstacle clearance requirements for the entire route segment and which assures acceptable navigational signal coverage only within 25 statute (22 nautical) miles of a VOR.</p>
+            <p id="mva"><strong>Minimum Vectoring Altitude (MVA)</strong><br />The lowest MSL altitude at which an IFR aircraft will be vectored by a radar controller, except as otherwise authorized for radar approaches, departures, and <a href="#missedapproach" class="navy-link">missed approaches</a>. The altitude meets IFR obstacle clearance criteria. It may be lower than the published <a href="#mea" class="navy-link">MEA</a>
+            along an airway or J-route segment. It may be utilized for radar vectoring only upon the controller's determination that an adequate radar return is being received from the aircraft being controlled. Charts depicting minimum vectoring altitudes are normally available only to the controllers and not to pilots.</p>
             <p id="missedapproach"><strong>Missed Approach</strong><br />
             <ol type="a">
                 <li>A maneuver conducted by a pilot when an instrument approach cannot be completed to a landing. The route of flight and altitude are shown on instrument approach procedure charts. A pilot executing a missed approach prior to the <a href="#map" class="navy-link">Missed Approach Point (MAP)</a> must continue along the final approach to the <a href="#map" class="navy-link">MAP</a>.</li>
@@ -206,6 +218,7 @@
                 <li>At locations where ATC radar services is provided, the pilot should conform to radar vectors when provided by ATC in lieu of the published missed approach procedure.</li>
                 </ol></p>
             <p id="map"><strong>Missed Approach Point (MAP)</strong><br />A point prescribed in each instrument approach procedure at which a <a href="#missedapproach" class="navy-link">missed approach</a> procedure shall be executed if the required visual reference does not exist.</p>
+
         </div>
     </div>
 </div>

--- a/source/templates/glossary.html
+++ b/source/templates/glossary.html
@@ -3,5 +3,210 @@
 {% block title %}Aviation Phraeseology Glossary{% endblock %}
 
 {% block content %}
-
+<div>
+    <div style="width=100%;">
+        <div class="content navy-font">
+            <h1 style="margin-top: 5px; margin-bottom: 10px;">Aviation Phraseology Glossary</h1>
+            <p>All definitions come from the Federal Aviation Administration's <a href="https://www.faa.gov/air_traffic/publications/media/pcg_10-12-17.pdf" target="_blank" class="navy-link">Pilot/Controller Glossary</a>. We are presenting only the
+            most commonly used terms and phrases. For a more in-depth look, please look throught the Pilot/Controller Glossary.</p>
+        </div>
+        <div class="content navy-font">
+            <h2 id="a">A</h2>
+            <p id="abeam"><strong>Abeam</strong><br />An aircraft is "abeam" a fix, point, or object when that fix, point, or object is approximately 90 degrees to the right
+            or left of the aircraft track. Abeam indicates a general position rather than a precise point.</p>
+            <p id="abort"><strong>Abort</strong><br />To terminate a preplaned aircraft maneuver; e.g., an aborted takeoff.</p>
+            <p id="acknowledge"><strong>Acknowledge</strong><br />Let me know that you have received and understood this message.</p>
+            <p id="advise"><strong>Advise Intentions</strong><br />Tell me what you plan to do.</p>
+            <p id="affirmative"><strong>Affirmative</strong><br />Yes.</p>
+            <p id="airmet"><strong>Airmen's Meteorological Information (AIRMET)</strong><br />In-flight weather advisories issued only to amend the area forecast concerning weather phenomena
+            which are of operational interest to all aircraft and potentially hazardous to aircraft having limited capability because of lack of equipment, instrumentation, or
+            pilot qualifications. AIRMETs concern weather of less severity than that covered by <a href="#sigmet" class="navy-link">SIGMET</a>s or <a href="#csigmets" class="navy-link">Convective SIGMETs</a>.
+            AIRMETs cover moderate icing, moderate turbulence, sustained winds of 30 knots or more at the surface, widespread areas
+            of ceilings less than 1,000 feet and/or visibility less than 3 miles, and extensive mountain obsurement.</p>
+            <p id="altread"><strong>Altitude Readout</strong><br />An aircraft's altitude, transmitted via the Mode C transponder feature, that is visually displayed in
+            100-foot increments on a radar scope having readout capability.</p>
+            <p id="altrestcan"><strong>Altitude Restrictions are Cancelled</strong><br />Adherence to previously imposed altitude restrictions
+            is no longer required during a climb or descent.</p>
+            <p id="approachsp"><strong>Approach Speed</strong><br />The recommended speed contained in aircraft manuals used by pilots when making an approach to landing. This speed will vary
+            for different segments of an approach as well as for aircraft weight and configuration.</p>
+            <p id="aocma"><strong>Appropriate Obstacle Clearance Minimum Altitude</strong><br />Any of the following:<br />
+            <ul>
+                <li><a href="#meria" class="navy-link">Minimum En Route IFR Altitude</a></li>
+                <li><a href="#mia" class="navy-link">Minimum IFR Altitude</a></li>
+                <li><a href="#moca" class="navy-link">Minimum Obstruction Clearance Altitude</a></li>
+                <li><a href="#mva" class="navy-link">Minimum Vectoring Altitude</a></li>
+             </ul></p>
+            <p id="aocma"><strong>Appropriate Terrain Clearance Minimum Altitude</strong><br />Any of the following:<br />
+            <ul>
+                <li><a href="#meria" class="navy-link">Minimum En Route IFR Altitude</a></li>
+                <li><a href="#mia" class="navy-link">Minimum IFR Altitude</a></li>
+                <li><a href="#moca" class="navy-link">Minimum Obstruction Clearance Altitude</a></li>
+                <li><a href="#mva" class="navy-link">Minimum Vectoring Altitude</a></li>
+             </ul></p>
+            <hr />
+        </div>
+        <div class="content navy-font">
+            <h2 id="b">B</h2>
+            <p id="backtaxi"><strong>Back-Taxi</strong><br />A term used by air traffic controllers to taxi an aircraft on the runway opposite to the traffic flow. The aircraft
+            may be instructed to back-taxi to the beginning of the runway or at some point before reaching the runway end for the purpose of departure or to exit the runway.</p>
+            <p id="bt"><strong>Blind Transmission</strong><br />A transmission from one station to other stations in circumstances where two-way communication cannot be established,
+            but where it is believed that the called stations may be able to receive the transmission.</p>
+            <p id="blocked"><strong>Blocked</strong><br />Phraseology used to indicate that a radio transmission has been distorted or interrupted due to multiple simultaneous radio transmissions.</p>
+            <hr />
+        </div>
+        <div class="content navy-font">
+            <h2 id="c">C</h2>
+            <p id="chase"><strong>Chase</strong><br />An aircraft flown in proximity to another aircraft normally to observe its performance during training or testing.</p>
+            <p id="circlerunway"><strong>Circle to Runway {Runway Number}</strong><br />Used by ATC to inform the pilot that he/she must circle to land because the runway in use is other than the runway
+            aligned with the instrument approach procedure. When the direction of the circling maneuver in relation to the airport/runway is required, the controller will state the direction (eight cardinal
+            compass points) and specify a left or right downwind or base leg as approprate; e.g., "Cleared VOR Runway Three Six Approach circle to Runway Two Two," or "Circle northwest of the airport for a right
+            downwind to Runway Two Two."</p>
+            <p id="clearance"><strong>Clearance</strong><br />An authorization by air traffic control for the purpose of preventing collision between known aircraft, for an aircraft to proceed under specified
+            traffic conditions within controlled airspace. The pilot-in-command of an aircraft may not deviate from the provisions of a visual flight rules (VFR) or instrument flight rules (IFR) air traffic
+            clearance except in an emergency or unless an amended clearance has been obtained.<br /><br />Additionally, the pilot may request a different clearance from that which has been issued by air traffic
+            control (ATC) if information available to the pilot makes another course of action more practicable or if aircraft equpment limitations or company procedures forbid compliance with the clearance issued.
+            Pilots may also request clarification or amendment, as appropriate, any time a clearance is not fully understood, or considered unacceptable because of safety of flight. Controllers should, in such instances
+            and to the extent of operational practicality and safety, honor the pilot's request.<br /><br /><i>14 CFR Part 91.3(a)</i> states: "The pilot in command of an aircraft is directly responsible for, and is the
+            final authority as to, the operation of that aircraft." <strong>The pilot is responsible to request an amended clearance if ATC issues a clearance that would cause a pilot to deviate from a rule or regulation,
+                         or in the pilot's opinion, would place the aircraft in jeopardy.</strong></p>
+            <p id="clearancevoid"><strong>Clearance Void If Not Off By {Time}</strong><br />Used by ATC to advise an aircraft that the departure clearance is automatically cancelled if takeoff is not made prior to
+            a specific time. The pilot must obtain a new clearance or cancel his/her IFR flight plan if not off by the specified time.</p>
+            <p id="clearedapproach"><strong>Cleared Approach</strong><br />ATC authorization for an aircraft to execute any standard or special instrument approach procedure for that airport. Normally, an aircraft will be
+            cleared for a specific instrument approach procedure.</p>
+            <p id="clearedtype"><strong>Cleared {Type Of} Approach</strong><br />ATC authorization for an aircraft to execure a specific instrument approach procedure to an airport; e.g., "Cleared ILS Runway Three Six Approach."</p>
+            <p id="clearedfiled"><strong>Cleared as Filed</strong><br />Means the aircraft is cleared to proceed in accordance with the route of flight filed in the flight plan. This clearance does not include the altitude, <a href="#dp" class="navy-link">DP</a>,
+            or <a href="#dptransition" class="navy-link">DP Transition</a>.</p>
+            <p id="cleartakeoff"><strong>Cleared for Takeoff</strong><br />ATC authorization for an aircraft to depart. It is predicated on known traffic and known physical airport conditions.</p>
+            <p id="clearoption"><strong>Cleared for the Option</strong><br />ATC authorization for an aircraft to make a touch-and-go, low approach, <a href="#missedapproach" class="navy-link">missed approach</a>, stop and go, or full stop landing at the discretion of the pilot.
+            It is normally used in training so that an instructor can evaluate a student's performance under changing situations. Pilots should advise ATC if they decide to remain on the runway, of any delay in their stop and go,
+            delay clearing the runway, or are unable to comply with the instruction(s).</p>
+            <p id="clearthrough"><strong>Cleared Through</strong><br />ATC authorization for an aircraft to make intermediate stops at specified airports without refiling a flight plan while en route to the clearance limit.</p>
+            <p id="clearland"><strong>Cleared to Land</strong><br />ATC authorization for an aircraft to land. It is predicated on known traffic and known physical airport conditions.</p>
+            <p id="climbvfr"><strong>Climb to VFR</strong><br />ATC authorization for an aircraft to climb to VFR conditions within Class B, C, D, and E surface areas when the only weather limitation is restricted visibility. The aircraft must
+            remain clear of clouds while climbing to VFR.</p>
+            <p id="complyrestrictions"><strong>Comply with Restrictions</strong><br />An ATC instruction that requires an aircraft being vectored back onto an arrival or departure procedure to comply with all altitude and/or speed restrictions depicted
+            on the procedure. This term may be used in lieu of repeating each remaining restriction that appears on the procedure.</p>
+            <p id="contactapproach"><strong>Contact Approach</strong><br />An approach wherein an aircraft on an IFR flight plan, having an air traffic control authorization, operating clear of clouds with at least 1 miles flight visibility and a reasonable expectation
+            of continuing to the destination airport in those conditions, may deviate from the instrument approach procedure and proceed to the destination airport by visual reference to the surface. This approach will only be authorized when
+            requested by the pilot and the reported ground visibility at the destination airport is at least 1 statute mile.</p>
+            <p id="continue"><strong>Continue</strong><br />When used as a control instruction should be followed by another word or words clarifying what is expected of the pilot. Example: "continue taxi," "continue descent," "continue inbound," etc.</p>
+            <p id="csigmets"><strong>Convective SIGMET</strong><br />A weather advisory concerning convective weather significant to the safety of all aircraft. Convective <a href="#sigmet" class="navy-link">SIGMET</a>s are issued for tornadoes, lines of thunderstorms, embedded thunderstorms of any intensity level, areas
+            of thunderstorms greater than or equal to VIP level 4 within an area coverage of 4/10 (40%) or more, and hail 3/4 inch or greater.</p>
+            <p id="crossfix"><strong>Cross {Fix} at {Altitude}</strong><br />Used by ATC when a specific altitude restriction at a specified fix is required.</p>
+            <p id="crossfixabove"><strong>Cross {Fix} at or Above {Altitude}</strong><br />Used by ATC when an altitude restriction at a specified fix is required. It does not prohibit the aircraft from crossing the fix at a higher altitude than specified; however,
+            the higher altitude may not be one that will violate a succeeding altitude restriction or altitude assignment.</p>
+            <p id="crossfixbelow"><strong>Cross {Fix} at or Below {Altitude}</strong><br />Used by ATC when a maximum crossing altitude at a specific fix is required. It does not prohibit the aircraft from crossing the fix at a lower altitude; however, it must be at or above the minimum
+            IFR altitude.</p>
+            <p id="cruise"><strong>Cruise</strong><br />Used in an ATC clearance to authorize a pilot to conduct flight at any altitude from the minimum IFR altitude up to and including the altitude specified in the clearance. The pilot may level off at any intermediate
+            altitude within this block of airspace. Climb/descent within the block is to be  made at the discretion of the pilot. However, once the pilot starts descent and verbally reports leaving an altitude in the block, he/she may not return to that altitude without additional
+            ATC clearance. Further, it is approval for the pilot to proceed to and make an approach at destination airport and can be used in conjunction with:
+                <ol type="a">
+                    <li>An airport clearance limit at locations with a standard/special instrument approach procedure. The CFRs require that if an instrument letdown to an airport is necessary, the pilot shall make the letdown in accordance with a standard/special
+                    instrument approach procedure for that airport, or</li>
+                    <li>An airport clearance limit at locations are within/below/outside controlled airspace and without a standard/special instrument approach procedure. Such a clearance is <strong>NOT AUTHORIZATION</strong> for the pilot to descend under IFR conditions
+                    below the applicable minimum IFR altitude nor does it imply that ATC is ecercising control over aircraft in Class G airspace; however, it provides a means for the aircraft to proceed to destination airport, descend, and land in accordance with applicable CFRs governing VFR
+                    flight operations. Also, this provides search and rescue protection until such time as the IFR flight plan is closed.</li>
+                </ol></p>
+            <hr />
+        </div>
+        <div class="content navy-font">
+            <h2 id="d">D</h2>
+            <p id="direct"><strong>Direct</strong><br />Straight line flight between to navigational aids, fixes, points, or any combination thereof. When used by pilots in describing off-airway routes, points defining direct route segments become compulsory reporting points unless the aircraft is under
+            radar contact.</p>
+            <hr />
+        </div>
+        <div class="content navy-font">
+            <h2 id="e">E</h2>
+            <p id="emergency"><strong>Emergency</strong><br />A distress or urgency condition.</p>
+            <p id="executemissed"><strong>Execute Missed Approach</strong><br />Instructions issued to a pilot making an instrument approach which means continue inbound the <a href="#map" class="navy-link">missed approach point</a> and execute the <a href="#missedapproach" class="navy-link">missed approach</a> procedure as described on the Instrument Approach Procedure Chart or as
+            previously assigned by ATC. The pilot may climb immediately to the altitude specified in the <a href="#missedapproach" class="navy-link">missed approach</a> procedure upon making a <a href="#missedapproach" class="navy-link">missed approach</a>. No turns should be initiated prior to reaching the <a href="#map" class="navy-link">missed approach point</a>. When conducting an ASR or PAR approach, execute the assigned
+            <a href="#missedapproach" class="navy-link">missed approach</a> procedure immediately upon receiving instructions to "execute <a href="#missedapproach" class="navy-link">missed approach</a>".</p>
+            <p id="expectat"><strong>Expect {Altitude} at {Time}/{Fix}</strong><br />Used under certain conditions to provide a pilot with an altitude to be used in the event of two-way communications failure. It also provides altitude information to assist the pilot in planning.</p>
+            <p id="expectfurther"><strong>Expect Further Clearance {Time}</strong><br />The time a pilot can expect to receive clearance beyond a clearance limit.</p>
+            <p id="expectfurthevia"><strong>Expect Further Clearance via {Airways, Routes, or Fixes}</strong><br />Used to inform a pilot of the routing he/she can expect if any part of the route beyond a short range clearance limit differs from that filed.</p>
+            <p id="expedite"><strong>Expedite</strong><br />Used by ATC when prompt compliance is required to avoid the development of an imminent situation. Expedite climb/descent normally indicates to a pilot that the approximate best rate of climb/descent should be used without requiring an exceptional
+            change in aircraft handling characteristics.</p>
+            <hr />
+        </div>
+        <div class="content navy-font">
+            <h2 id="f">F</h2>
+            <p id="final"><strong>Final</strong><br />Commonly used to mean that an aircraft is on the final approach course or is aligned with a landing area.</p>
+            <p id="fl"><strong>Flight Level (FL)</strong><br />A level of constant atmospheric pressure related to a reference datum of 29.92 inches of mercury. Each is stated in three digits that represent hundreds of feet. For example, flight level (FL) 250 represents barometric altimeter indication
+            of 25,000 fefet; FL 255, an indication of 25,500 feet.</p>
+            <p id="frc"><strong>Full Route Clearance (FRC)</strong></p>
+            <hr />
+        </div>
+        <div class="content navy-font">
+            <h2 id="g">G</h2>
+            <p id="goahead"><strong>Go Ahead</strong><br />Proceed with your message. <i>Not to be used for any other purpose.</i></p>
+            <p id="goaround"><strong>Go Around</strong><br />Insstructions for a pilot to abandon his/her approach to landing. Additional instructions may follow. Unless otherwise advised by ATC, a VFR aircraft or an aircraft conducting visual approach should overfly the runway while climbing to traffic pattern
+            altitude and enter the traffic pattern via the crosswind leg. A pilot on an IFR flight plan making an instrument approach should execute the published <a href="#missedapproach" class="navy-link">missed approach</a> procedure or proceed as instructed by ATC; e.g., "Go around" (additional instructions if required).</p>
+            <hr />
+        </div>
+        <div class="content navy-font">
+            <h2 id="h">H</h2>
+            <p id="havenums"><strong>Have Numbers</strong><br />Used by pilots to inform ATC that they have received runway, wind, and altimeter information only.</p>
+            <p id="heavy"><strong>Heavy {Aircraft}</strong><br />Aircraft capable of takeoff weights of 300,000 pounds or more whether or not they are operating at this weight during a particular phase of flight.</p>
+            <p id="homing"><strong>Homing</strong><br />Flight toward a <a href="#navaid" class="navy-link">NAVAID</a>, without correcting for wind, by adjusting heading to maintain a relative bearing of zero degrees.</p>
+            <p id="hear"><strong>How do you Hear Me?</strong><br />A question relating to the quality of the transmission or to determine how well the transmission is being received.</p>
+            <hr />
+        </div>
+        <div class="content navy-font">
+            <h2 id="i">I</h2>
+            <p id="isayagain"><strong>I Say Again</strong><br />The message will be repeated.</p>
+            <p id="ident"><strong>Ident</strong><br />A request for a pilor to activate the aircraft transponder identification feature. This will help the controller to confirm an aircraft identity or to identify an aircraft.</p>
+            <p id="ifnotransmission"><strong>If No Transmission Received For {Time}</strong><br />Used by ATC in radar approaches to prefix procedures which should be followed by the pilot in event of lost communications.</p>
+            <p id="immediately"><strong>Immediately</strong><br />Used by ATC or pilots when such action compliance is required to avoid an imminent situation.</p>
+            <p id="increasespeed"><strong>Increase Speed to {Speed}</strong><br />An ATC procedure used to request pilots to adjust aircraft speed to a specific value for the purpose of providing a desired spacing. Pilots are expected to maintain a speed of plus or minus 10 knots or 0.02 Mach number of the specified speed.
+            Examples of speed adjustments are:
+                <ol type="a">
+                    <li>"Increase speed to Mach point (number.)"</li>
+                    <li>"Increase speed to (speed in knots)" or "Increase speed (number of knots) knots."</li>
+                </ol>
+            </p>
+            <hr />
+        </div>
+        <div class="content navy-font">
+            <h2 id="j">J</h2>
+            <p>No commonly used terms/phrases. Please check the <a href="https://www.faa.gov/air_traffic/publications/media/pcg_10-12-17.pdf" target="_blank" class="navy-link">FAA Glossary</a> for more in-depth terms and definitions.</p>
+            <hr />
+        </div>
+        <div class="content navy-font">
+            <h2 id="k">K</h2>
+            <p>No commonly used terms/phrases. Please check the <a href="https://www.faa.gov/air_traffic/publications/media/pcg_10-12-17.pdf" target="_blank" class="navy-link">FAA Glossary</a> for more in-depth terms and definitions.</p>
+        </div>
+        <div class="content navy-font">
+            <hr />
+            <h2 id="l">L</h2>
+            <p id="lowaltitudealert">
+                <strong>Low Altitude Alert, Check Your Altitude Immediately</strong><br />A safety alert issued by ATC to aircraft under their control if ATC is aware the aircraft is at an altitude which, in the controller's judgement, places the aircraft in unsafe proximity to terrain, obstructions, or other aircraft.
+                The controller may discontinue the issuance of further alerts if the pilot advises he/she is taking action to correct the situation or has the other aircraft in sight.
+                <ol type="a">
+                    <li><strong>Terrain/Obstruction Alert</strong><br />A safety alert issued by ATC to aircraft under their control if ATC is aware the aircraft is at an altitude which, in the controller's judgement, places the aircraft in unsafe proximity to terrain/obstructions.'</li>
+                    <li>
+                        <strong>Aircraft Conflict Alert</strong><br />A safety alert issued by ATC to aircraft under their control if ATC is aware of an aircraft that is not under their control at an altitude which, in the controller's judgement, places both aircraft in unsafe proximity to each other. With the alert, ATC will offer the pilot an alternate course of action
+                        when feasible.
+                    </li>
+                </ol>
+            </p>
+        </div>
+        <div class="content navy-font">
+            <hr />
+            <h2 id="m">M</h2>
+            <p id="maintain"><strong>Maintain</strong><br />
+            <ol type="a">
+                <li>Concerning altitude/flight level, the term means to remain at the altitude/flight level specified. The phrase "climb and" or "descend and" normally precedes "maintain" and the altitude assignment; e.g., "descend and maintain 5,000."</li>
+                <li>Concerning other ATC instructions, the term is used in its literal sense; e.g., maintain VFR.</li>
+                </ol></p>
+            <p id="makeshortapproach"><strong>Make Short Approach</strong><br />Used by ATC to inform a pilot to alter his/her traffic patter so as to make a short final approach.</p>
+            <p id="missedapproach"><strong>Missed Approach</strong><br />
+            <ol type="a">
+                <li>A maneuver conducted by a pilot when an instrument approach cannot be completed to a landing. The route of flight and altitude are shown on instrument approach procedure charts. A pilot executing a missed approach prior to the <a href="#map" class="navy-link">Missed Approach Point (MAP)</a> must continue along the final approach to the <a href="#map" class="navy-link">MAP</a>.</li>
+                <li>A term used by the pilot to inform ATC that he/she is executing the missed approach.</li>
+                <li>At locations where ATC radar services is provided, the pilot should conform to radar vectors when provided by ATC in lieu of the published missed approach procedure.</li>
+                </ol></p>
+            <p id="map"><strong>Missed Approach Point (MAP)</strong><br />A point prescribed in each instrument approach procedure at which a <a href="#missedapproach" class="navy-link">missed approach</a> procedure shall be executed if the required visual reference does not exist.</p>
+        </div>
+    </div>
+</div>
 {% endblock %}

--- a/source/templates/glossary.html
+++ b/source/templates/glossary.html
@@ -138,7 +138,6 @@
             <p id="final"><strong>Final</strong><br />Commonly used to mean that an aircraft is on the final approach course or is aligned with a landing area.</p>
             <p id="fl"><strong>Flight Level (FL)</strong><br />A level of constant atmospheric pressure related to a reference datum of 29.92 inches of mercury. Each is stated in three digits that represent hundreds of feet. For example, flight level (FL) 250 represents barometric altimeter indication
             of 25,000 fefet; FL 255, an indication of 25,500 feet.</p>
-            <p id="frc"><strong>Full Route Clearance (FRC)</strong></p>
             <hr />
         </div>
         <div class="content navy-font">

--- a/source/templates/template.html
+++ b/source/templates/template.html
@@ -25,6 +25,7 @@
                         <li><a class="navy-font" href="{{ url_for('contact.contact') }}">Contact</a></li>
                         <li><a class="navy-font" href="{{ url_for('map.map', type='geo') }}">Interactive Map</a></li>
                         <li><a class="navy-font" href="{{ url_for('replay.replay') }}">Replay Audio</a></li>
+                        <li><a class="navy-font" href="{{ url_for('glossary.glossary') }}">Glossary</a></li>
                     </ul>
                 </nav>
             </div>


### PR DESCRIPTION
Adds glossary of most common phrases in aviation phraeseology. Links to FAA glossary otherwise.